### PR TITLE
Simplify hero

### DIFF
--- a/index.md
+++ b/index.md
@@ -9,9 +9,6 @@ description: Learn about Blazor, an experimental .NET web framework using C#/Raz
     <div style="text-align:center;font-size:64px">
       <span><strong>Blazor</strong></span>
     </div>
-    <div class="buttons-unit-small">
-      <a class="version-link" href="/docs/get-started.html">Get Started</a><span>|</span><a class="github-link" href="https://github.com/aspnet/blazor">Blazor at Github</a>
-    </div>
     <div class="minitext">
         Full-stack web development with C# and WebAssembly
     </div>

--- a/stylesheets/main.css
+++ b/stylesheets/main.css
@@ -148,7 +148,7 @@ svg:hover path {
 }
 
 .buttons-unit {
-  margin-top: 60px;
+  margin-top: 50px;
   text-align: center;
 }
 


### PR DESCRIPTION
The extra Get Started link seems redundant and the GitHub link is already later in the doc. Simplifying the hero focuses the user on the main action we care about, which is to Get Started.