### PR TITLE
HTML5 compliance

### DIFF
--- a/index.md
+++ b/index.md
@@ -129,11 +129,9 @@ documentType: index
 <div class="get-started-section">
   <div class="container">
     <div class="row">
-      <section>
-        <div class="buttons-unit">
-          <a href="/docs/get-started.html" class="btn btn-primary" style="font-size:2em;display:inline;padding:15px"><i class="glyphicon glyphicon-send" style="font-size:1em;padding:0 20px 0 0"></i>Get Started</a>
-        </div>
-      </section>
+      <div class="buttons-unit" style="padding-bottom:50px">
+        <a href="/docs/get-started.html" class="btn btn-primary" style="font-size:2em;display:inline;padding:15px"><i class="glyphicon glyphicon-send" style="font-size:1em;padding:0 20px 0 0"></i>Get Started</a>
+      </div>
     </div>
   </div>
 </div>

--- a/template/index.html.tmpl
+++ b/template/index.html.tmpl
@@ -5,7 +5,7 @@
 {{!include(logo.svg)}}
 <!DOCTYPE html>
 <!--[if IE]><![endif]-->
-<html>
+<html lang="en">
   {{>partials/head}}
   <body data-spy="scroll" data-target="#affix">
     <div id="wrapper">


### PR DESCRIPTION
Silly PR perhaps, but I see two quick standards compliance things we can do ...

* Since we're not localized, we can add the `lang` attribute.
* The section that fixed the button/footer problem was only supplying a `padding-bottom:50px`; so instead of a **\<section>**, I swapped it with the inline style to make the validation happy (i.e., there was no heading in the **\<section>**, so it choked).