### PR TITLE
Accessibility compliance

### DIFF
--- a/index.md
+++ b/index.md
@@ -6,9 +6,9 @@ documentType: index
 
 <div class="hero">
   <div class="wrap">
-    <div class="text">
+    <h1 class="text">
       <strong>Blazor</strong>
-    </div>
+    </h1>
     <div class="minitext">
         Full-stack web development with C# and WebAssembly
     </div>
@@ -25,7 +25,7 @@ documentType: index
         <section>
           <h2>Build a Web UI with C#</h2>
           <p class="lead">Blazor is an experimental .NET web framework using C# and HTML that runs in the browser.</p>
-          <p class="lead"><a href="/docs/introduction/faq.html">What is Blazor?</a></p>
+          <div class="lead"><a href="/docs/introduction/faq.html">What is Blazor?</a></div>
         </section>
       </div>
     </div>
@@ -38,7 +38,7 @@ documentType: index
         <section>
           <h2>Full-stack .NET</h2>
           <p class="lead">Do full-stack .NET development using stable and consistent tools, languages, and APIs both in the browser and on the server.</p>
-          <p class="lead"><a href="https://www.microsoft.com/net">Learn more about the .NET platform</a></p>
+          <div class="lead"><a href="https://www.microsoft.com/net">Learn more about the .NET platform</a></div>
         </section>
         <i class="glyphicon glyphicon-tasks"></i>
       </div>
@@ -53,7 +53,7 @@ documentType: index
         <section>
           <h2>Runs in all browsers and implements .NET Standard</h2>
           <p class="lead">Blazor runs in all browsers on the real .NET runtime with full support for .NET Standard. Blazor requires no plugins and no code transpilation, only open web standards.</p>
-          <p class="lead"><a href="/docs/introduction/index.html">How Blazor works</a></p>
+          <div class="lead"><a href="/docs/introduction/index.html">How Blazor works</a></div>
         </section>
       </div>
     </div>
@@ -106,7 +106,7 @@ documentType: index
         <section>
           <h2>Get involved</h2>
           <p class="lead">Join the community that's building Blazor, writing documentation, building samples, and more!</p>
-          <p class="lead"><a href="community.md">Community</a></p>
+          <div class="lead"><a href="community.md">Community</a></div>
         </section>
       </div>
     </div>
@@ -119,7 +119,7 @@ documentType: index
         <section>
           <h2>Open-source & free </h2>
           <p class="lead">Blazor is part of the open-source .NET platform that has a strong community of over 25,000 contributors from over 1,700 companies.</p>
-          <p class="lead"><a href="https://github.com/aspnet/blazor">Blazor on GitHub</a></p>
+          <div class="lead"><a href="https://github.com/aspnet/blazor">Blazor on GitHub</a></div>
         </section>
         <i class="glyphicon glyphicon-road"></i>
       </div>

--- a/template/logo.svg
+++ b/template/logo.svg
@@ -14,7 +14,9 @@
    preserveAspectRatio="xMidYMid meet"
    id="svg12"
    sodipodi:docname="logo.svg"
-   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   aria-labelledby="svgtitle">
+  <title id="svgtitle" lang="en">Return to homepage</title>
   <defs
      id="defs16" />
   <sodipodi:namedview

--- a/template/styles/main.css
+++ b/template/styles/main.css
@@ -125,6 +125,7 @@ svg:hover path {
 .hero .text {
   font-size: 64px;
   text-align: center;
+  font-family: 'Segoe UI', Tahoma, Helvetica, sans-serif;
 }
 
 .hero .minitext {


### PR DESCRIPTION
Here's a second quickie PR. We can't fix every accessibility issue because some of them are baked into DocFX. We can fix a few tho ...

* There's no **\<h1>** on the landing page. We can add a `font-family` to `.hero .text` and change the **\<div>** around "Blazor" to an **\<h1>**.
* There's nothing really wrong with the short **\<p>** element content in each section that contains a link (i.e., they aren't really headings, so we don't really need to fix these warnings). However, it's an easy change to convert them into **\<div>** elements to make the validator happy.
* Our SVG logo could use a "Return to homepage" title. In spite of online sources saying it will provide rollover tooltip text, I didn't see that in the browser. Anyway, the added **\<title>** should help when using a screen reader.

I recommend someone else build this locally just to make sure nothing breaks. It looks ok here, but I'd feel better with another pair of :eyes: on it.