### PR TITLE
Temporarily use raw GH user content image links

### DIFF
--- a/docs/tutorials/build-your-first-blazor-app.md
+++ b/docs/tutorials/build-your-first-blazor-app.md
@@ -23,11 +23,11 @@ To create the project in Visual Studio:
 
 1. Select **File** > **New** > **Project**. Select **Web** > **ASP.NET Core Web Application**. Name the project "BlazorApp1" in the **Name** field. Select **OK**.
 
-    ![New ASP.NET Core project](build-your-first-blazor-app/_static/new-aspnet-core-project.png)
+    ![New ASP.NET Core project](https://raw.githubusercontent.com/aspnet/Blazor.Docs/gh-pages/docs/tutorials/build-your-first-blazor-app/_static/new-aspnet-core-project.png)
 
 1. The **New ASP.NET Core Web Application** dialog appears. Make sure **.NET Core** is selected at the top. Select either **ASP.NET Core 2.0** or **ASP.NET Core 2.1**. Choose the **Blazor** template and select **OK**.
 
-    ![New Blazor app dialog](build-your-first-blazor-app/_static/new-blazor-app-dialog.png)
+    ![New Blazor app dialog](https://raw.githubusercontent.com/aspnet/Blazor.Docs/gh-pages/docs/tutorials/build-your-first-blazor-app/_static/new-blazor-app-dialog.png)
 
 1. Once the project is created, press **Ctrl-F5** to run the app *without the debugger*. Running with the debugger (**F5**) isn't supported at this time.
 
@@ -447,11 +447,11 @@ When using Visual Studio, perform the following steps to publish the Todo Blazor
 
 1. In the **Pick a publish target** dialog, select **App Service** and **Create New**. Select **Publish**.
 
-    ![Pick a publish target](build-your-first-blazor-app/_static/blazor-publish-pick-target.png)
+    ![Pick a publish target](https://raw.githubusercontent.com/aspnet/Blazor.Docs/gh-pages/docs/tutorials/build-your-first-blazor-app/_static/blazor-publish-pick-target.png)
 
 1. In the **Create App Service** dialog, choose a name for the app and select the subscription, resource group, and hosting plan. Select **Create** to create the app service and publish the app.
 
-    ![Create app service](build-your-first-blazor-app/_static/blazor-publish-create-appservice2.png)
+    ![Create app service](https://raw.githubusercontent.com/aspnet/Blazor.Docs/gh-pages/docs/tutorials/build-your-first-blazor-app/_static/blazor-publish-create-appservice2.png)
 
 Wait a minute or so for the app to be deployed.
 


### PR DESCRIPTION
Addresses #62 

@floreseken Let's hack this ... a classic 🚑 **_RexHack_**:tm: 🚒 ... and point these at the raw GH user content links for now.

These images *are* making their way to the **live** branch, and they are making their way to the **gh-pages** branch. They aren't available via the blazor.net domain URLs with GH Pages. Nothing is obviously wrong with the *releaseDocs.sh* script, so it might be the GH Pages domain redirect/relative links that aren't working properly. I think @danroth27 will tell us what the real solution is here.

As a temporary fix, this hack should be fine.