### PR TITLE
docfx.json updates to match aspnet/Docs

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -17,38 +17,34 @@
       {
         "files": [
           "api/**.yml",
-          "api/index.md"
-        ]
-      },
-      {
-        "files": [
-          "docs/**.md",
-          "docs/**/toc.md",
           "toc.yml",
-          "*.md"
-        ]
+          "**/*.md"
+        ],
+        "exclude": [
+          "**/obj/**",
+          "**/sample/**",
+          "**/samples/**",
+          "**/includes/**",
+          "_site/**"
+        ],
+        "src": "."
       }
     ],
     "resource": [
       {
         "files": [
           "**/*.png",
-          "**/*.jpg",
-          "stylesheets/**"
-        ]
-      }
-    ],
-    "overwrite": [
-      {
-        "files": [
-          "apidoc/**.md"
+          "**/*.jpg"
         ],
         "exclude": [
-          "obj/**",
+          "**/obj/**",
+          "**/includes/**",
           "_site/**"
-        ]
+        ],
+        "src": "."
       }
     ],
+    "overwrite": [],
     "dest": "_site",
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],


### PR DESCRIPTION
When I was looking at the problem with broken relative image links, I noticed a handful of DocFX config diffs between the config here and that of aspnet/Docs.

If these updates aren't sane ... or even just toooooo risky ... please just **close this**.

I don't want to cause an *international incident* here. :smile: