### PR TITLE
Add link to 0.3.0 release notes

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -61,6 +61,7 @@ Blazor preview documentation is provided to assist you in trying out Blazor. We 
 
 ## Blazor release notes
 
+* [Release notes (0.3.0)](https://github.com/aspnet/Blazor/releases/tag/0.3.0)
 * [Release notes (0.2.0)](https://github.com/aspnet/Blazor/releases/tag/0.2.0)
 * [Release notes (0.1.0)](https://github.com/aspnet/Blazor/releases/tag/0.1.0)
 


### PR DESCRIPTION
Index contains links to 0.2.0 and 0.1.0 release notes, doesn't include latest 0.3.0 release notes.