### PR TITLE
Add BlazorChatSample app to Samples section

### DIFF
--- a/community.md
+++ b/community.md
@@ -25,6 +25,7 @@ Below is a list of projects and resources from the Blazor community (links in ea
 * [Blazor Tour of Heroes](https://github.com/lohithgn/blazor-tour-of-heroes)
 * [Blazor To-Do App](https://github.com/BorowskiKamil/blazor-tasks)
 * [Blazor + Electron sample](https://github.com/SteveSandersonMS/BlazorElectronExperiment.Sample)
+* [Blazor Chat sample](https://github.com/conficient/BlazorChatSample) using SignalR via JS interop [demo](https://blazorchatsample.azurewebsites.net/)
 
 ## Tooling
 

--- a/community.md
+++ b/community.md
@@ -20,12 +20,12 @@ Below is a list of projects and resources from the Blazor community (links in ea
 ## Samples
 
 * [Blazor Bricks](https://www.codeproject.com/Articles/1241210/WebAssembly-with-Blazor)
+* [Blazor Chat sample](https://github.com/conficient/BlazorChatSample) using SignalR via JS interop ([Demo](https://blazorchatsample.azurewebsites.net/))
 * [Blazor Hacker News Clone](https://github.com/lohithgn/blazor-hackernews-clone)
 * [Blazor RealWorld example app](https://github.com/torhovland/blazor-realworld-example-app)
 * [Blazor Tour of Heroes](https://github.com/lohithgn/blazor-tour-of-heroes)
 * [Blazor To-Do App](https://github.com/BorowskiKamil/blazor-tasks)
 * [Blazor + Electron sample](https://github.com/SteveSandersonMS/BlazorElectronExperiment.Sample)
-* [Blazor Chat sample](https://github.com/conficient/BlazorChatSample) using SignalR via JS interop [demo](https://blazorchatsample.azurewebsites.net/)
 
 ## Tooling
 


### PR DESCRIPTION
I wrote a proof-of-concept Blazor chat application that uses SignalR Javascript client + interop
