### PR TITLE
Document how to configure IL linking

### DIFF
--- a/docs/host-and-deploy/configure-linker.md
+++ b/docs/host-and-deploy/configure-linker.md
@@ -1,0 +1,81 @@
+---
+title: Configure the Linker
+author: guardrex
+description: Learn how to control the Intermediate Language (IL) Linker when building a Blazor app.
+manager: wpickett
+ms.author: riande
+ms.custom: mvc
+ms.date: 08/19/2018
+ms.prod: asp.net-core
+ms.technology: aspnet
+ms.topic: article
+uid: client-side/blazor/host-and-deploy/configure-linker
+---
+# Configure the Linker
+
+By [Luke Latham](https://github.com/guardrex)
+
+[!INCLUDE[](~/includes/blazor-preview-notice.md)]
+
+Blazor performs [Intermediate Language (IL)](https://docs.microsoft.com/dotnet/standard/managed-code#intermediate-language--execution) linking during each Release mode build to remove unnecessary IL from the output assemblies.
+
+You can control assembly linking with either of the following approaches:
+
+* Disable linking globally with an MSBuild property.
+* Control linking on a per-assembly basis with a configuration file.
+
+## Disable linking with an MSBuild property
+
+Linking is enabled by default in Release mode when an app is built, which includes publishing. To disable linking for all assemblies, set the `<BlazorLinkOnBuild>` MSBuild property to `false` in the project file:
+
+```xml
+<PropertyGroup>
+  <BlazorLinkOnBuild>false</BlazorLinkOnBuild>
+</PropertyGroup>
+```
+
+## Control linking with a configuration file
+
+Linking can be controlled on a per-assembly basis by providing an XML configuration file and specifying the file as an MSBuild item in the project file.
+
+The following is an example configuration file (*Linker.xml*):
+
+```xml
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  This file specifies which parts of the BCL or Blazor packages must not be
+  stripped by the IL Linker even if they aren't referenced by user code.
+-->
+<linker>
+  <assembly fullname="mscorlib">
+    <!--
+      Preserve the methods in WasmRuntime because its methods are called by 
+      JavaScript client-side code to implement timers.
+      Fixes: https://github.com/aspnet/Blazor/issues/239
+    -->
+    <type fullname="System.Threading.WasmRuntime" />
+  </assembly>
+  <assembly fullname="System.Core">
+    <!--
+      System.Linq.Expressions* is required by Json.NET and any 
+      expression.Compile caller. The assembly isn't stripped.
+    -->
+    <type fullname="System.Linq.Expressions*" />
+  </assembly>
+  <!--
+    In this example, the app's entry point assembly is listed. The assembly
+    isn't stripped by the IL Linker.
+  -->
+  <assembly fullname="MyCoolBlazorApp" />
+</linker>
+```
+
+To learn more about the file format for the configuration file, see [IL Linker: Syntax of xml descriptor](https://github.com/mono/linker/blob/master/linker/README.md#syntax-of-xml-descriptor).
+
+Specify the configuration file in the project file with the `BlazorLinkerDescriptor` item:
+
+```xml
+<ItemGroup>
+  <BlazorLinkerDescriptor Include="Linker.xml" />
+</ItemGroup>
+```

--- a/docs/host-and-deploy/index.md
+++ b/docs/host-and-deploy/index.md
@@ -29,6 +29,10 @@ dotnet publish -c Release
 
 The assets in the *publish* folder are deployed to the web server. Deployment might be a manual or automated process depending on the development tools in use.
 
+## Configure the Linker
+
+Blazor performs Intermediate Language (IL) linking on each build to remove unnecessary IL from the output assemblies. You can control assembly linking on build. For more information, see <xref:client-side/blazor/host-and-deploy/configure-linker>.
+
 ## Rewrite URLs for correct routing
 
 Routing requests for page components in a client-side app isn't as simple as routing requests to a server-side, hosted app. Consider a client-side app with two pages:

--- a/docs/introduction/index.md
+++ b/docs/introduction/index.md
@@ -83,7 +83,7 @@ Blazor offers the core facilities that most apps require, including:
 * Routing
 * Dependency injection
 
-All of these features are optional. When one of these features isn't used in an app, the implementation is stripped out of the app when published by the IL linker.
+All of these features are optional. When one of these features isn't used in an app, the implementation is stripped out of the app when published by the [Intermediate Language (IL) Linker](xref:client-side/blazor/host-and-deploy/configure-linker).
 
 ## Code sharing and .NET Standard
 

--- a/docs/toc.md
+++ b/docs/toc.md
@@ -9,4 +9,5 @@
 # [Debugging](xref:client-side/blazor/debugging)
 # [Host and deploy](xref:client-side/blazor/host-and-deploy/index)
 ## [Hosting models](xref:client-side/blazor/host-and-deploy/hosting-models)
+## [Configure the Linker](xref:client-side/blazor/host-and-deploy/configure-linker)
 # [FAQ](xref:client-side/blazor/introduction/faq)


### PR DESCRIPTION
Fixes #223 

* The draft title is *Configure the Linker*. I didn't use "IL" in the title because we should define it ["Intermediate Language (IL)"] on first use. I felt that was a bit long-winded for the title. It's defined in the topic description and first line of text (with a link to more info).
* The config file seems to work fine with the declaration, so I include it. 
  `<?xml version="1.0" encoding="UTF-8" ?>`

Thanks to @Suchiman for the example.