### PR TITLE
Add BlazorSignalR library

### DIFF
--- a/community.md
+++ b/community.md
@@ -13,7 +13,7 @@ Below is a list of projects and resources from the Blazor community (links in ea
 * [BlazoredLocalStorage](https://github.com/chrissainty/BlazoredLocalStorage) &ndash; A library to provide access to local storage in Blazor apps.
 * [BlazorMaterial](https://github.com/BlazorExtensions/BlazorMaterial) &ndash; Blazor components implementing Google's Material components for web ([Material Design: Web](https://material.io/components/web)).
 * [Blazorous](https://github.com/chanan/Blazorous) &ndash; Maintainable CSS with Blazor.
-* [BlazorSignalR](https://github.com/csnewman/BlazorSignalR) &ndash; SignalR Core .NET client support for Blazor.
+* [BlazorSignalR](https://github.com/csnewman/BlazorSignalR) &ndash; ASP.NET Core SignalR Core .NET client support for Blazor.
 * [BlazorStorage](https://github.com/cloudcrate/BlazorStorage) &ndash; Blazor local and session storage support.
 * [BlazorStrap](https://github.com/chanan/BlazorStrap) &ndash; Bootstrap 4 Components for Blazor.
 * [Blazor Fluxor](https://mrpmorris.github.io/blazor-fluxor/) &ndash; Flux/Redux library

--- a/community.md
+++ b/community.md
@@ -13,6 +13,7 @@ Below is a list of projects and resources from the Blazor community (links in ea
 * [BlazoredLocalStorage](https://github.com/chrissainty/BlazoredLocalStorage) &ndash; A library to provide access to local storage in Blazor apps.
 * [BlazorMaterial](https://github.com/BlazorExtensions/BlazorMaterial) &ndash; Blazor components implementing Google's Material components for web ([Material Design: Web](https://material.io/components/web)).
 * [Blazorous](https://github.com/chanan/Blazorous) &ndash; Maintainable CSS with Blazor.
+* [BlazorSignalR](https://github.com/csnewman/BlazorSignalR) &ndash; SignalR Core .NET client support for Blazor.
 * [BlazorStorage](https://github.com/cloudcrate/BlazorStorage) &ndash; Blazor local and session storage support.
 * [BlazorStrap](https://github.com/chanan/BlazorStrap) &ndash; Bootstrap 4 Components for Blazor.
 * [Blazor Fluxor](https://mrpmorris.github.io/blazor-fluxor/) &ndash; Flux/Redux library


### PR DESCRIPTION
Adds BlazorSignalR library to community file.

See https://github.com/csnewman/BlazorSignalR. Works very differently to existing signalr library for blazor.