### PR TITLE
Add note to remove the global.json file

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -45,7 +45,7 @@ Congrats! You just ran your first Blazor app!
 ![Blazor app home page](https://msdnshared.blob.core.windows.net/media/2018/04/blazor-bootstrap-4.png)
 
 > [!IMPORTANT]
-> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. The *global.json* file pins the project to 2.1.3xx; so if you don't have that specific version range installed, the project fails to load or run. To workaround this issue, remove the *global.json* file from the project.
+> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. The *global.json* file pins the project to 2.1.3xx; so if you don't have that specific version range installed, the project fails to load or run. The workaround is to remove the *global.json* file from the project.
 
 ## Help & feedback
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -44,7 +44,8 @@ Congrats! You just ran your first Blazor app!
 
 ![Blazor app home page](https://msdnshared.blob.core.windows.net/media/2018/04/blazor-bootstrap-4.png)
 
-> NOTE: The default *global.json* include with Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. To workaround this issue remove the *global.json* file from the project.
+> [!IMPORTANT]
+> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. To workaround this issue, remove the *global.json* file from the project.
 
 ## Help & feedback
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -45,7 +45,7 @@ Congrats! You just ran your first Blazor app!
 ![Blazor app home page](https://msdnshared.blob.core.windows.net/media/2018/04/blazor-bootstrap-4.png)
 
 > [!IMPORTANT]
-> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx or later of the .NET Core SDK installed. To workaround this issue, remove the *global.json* file from the project.
+> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. To workaround this issue, remove the *global.json* file from the project.
 
 ## Help & feedback
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -45,7 +45,7 @@ Congrats! You just ran your first Blazor app!
 ![Blazor app home page](https://msdnshared.blob.core.windows.net/media/2018/04/blazor-bootstrap-4.png)
 
 > [!IMPORTANT]
-> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. To workaround this issue, remove the *global.json* file from the project.
+> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. The *global.json* file pins the project to 2.1.3xx; so if you don't have that specific version range installed, the project fails to load or run. To workaround this issue, remove the *global.json* file from the project.
 
 ## Help & feedback
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -45,7 +45,7 @@ Congrats! You just ran your first Blazor app!
 ![Blazor app home page](https://msdnshared.blob.core.windows.net/media/2018/04/blazor-bootstrap-4.png)
 
 > [!IMPORTANT]
-> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. To workaround this issue, remove the *global.json* file from the project.
+> The default *global.json* file included in the Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx or later of the .NET Core SDK installed. To workaround this issue, remove the *global.json* file from the project.
 
 ## Help & feedback
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -44,6 +44,8 @@ Congrats! You just ran your first Blazor app!
 
 ![Blazor app home page](https://msdnshared.blob.core.windows.net/media/2018/04/blazor-bootstrap-4.png)
 
+> NOTE: The default *global.json* include with Blazor project templates may cause the project to fail to load or run if you don't have version 2.1.3xx of the .NET Core SDK installed. To workaround this issue remove the *global.json* file from the project.
+
 ## Help & feedback
 
 Your feedback is especially important to us during this experimental phase for Blazor. If you run into issues or have questions while trying out Blazor, please let us know!


### PR DESCRIPTION
Lots of folks using 0.5.1 are hitting issues with the *global.json* file included with the project templates. Adding a note to the docs to tell folks to remove the *global.json* file. This issue is fixed in the upcoming 0.6.0 release.