### PR TITLE
Added troubleshooting tips for getting debugging to work

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -56,3 +56,10 @@ You *can't*:
 * Perform most other ordinary debugging scenarios.
 
 Development of further debugging scenarios is an on-going focus of the engineering team.
+
+## Troubleshooting tips
+
+If you are running into errors, the following tips may help.
+
+* Use the HTTP URL for your app instead of the HTTPS to debug.
+* In the debugger tab, open the console in your developer tools and clear the local storage. Then try re-launching the window. You can clear the local storage with this JS function: localStorage.clear()

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -57,8 +57,8 @@ You *can't*:
 
 Development of further debugging scenarios is an on-going focus of the engineering team.
 
-## Troubleshooting tips
+## Troubleshooting tip
 
-If you are running into errors, the following tip may help.
+If you're running into errors, the following tip may help:
 
-* In the debugger tab, open the developer tools in your browser, and in the console, execute localStorage.clear(). This will remove any breakpoints that were set.
+In the **debugger** tab, open the developer tools in your browser. In the console, execute `localStorage.clear()` to remove any breakpoints.

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -59,7 +59,6 @@ Development of further debugging scenarios is an on-going focus of the engineeri
 
 ## Troubleshooting tips
 
-If you are running into errors, the following tips may help.
+If you are running into errors, the following tip may help.
 
-* Use the HTTP URL for your app instead of the HTTPS to debug.
-* In the debugger tab, open the console in your developer tools and clear the local storage. Then try re-launching the window. You can clear the local storage with this JS function: localStorage.clear()
+* In the debugger tab, open the developer tools in your browser, and in the console, execute localStorage.clear(). This will remove any breakpoints that were set.


### PR DESCRIPTION
Fixes #269 

This is my proposal to add some additional help for trying out debugging.

I was able to make it work by using the HTTP URL instead of the HTTPS.

@danroth27 did the clear local storage in one of his demos which seemed to make it work.

I noticed Dan (or someone) also mentioned switching back & forth between Server Side hosting & Client Side hosting to debug. Would mentioning how to do that be of value? If I recall correctly, you change two lines of code.