### PR TITLE
Document async event handlers

### DIFF
--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -222,6 +222,21 @@ The following code calls the `CheckboxChanged` method when the check box is chan
 }
 ```
 
+Event handlers can also be asynchronous and return a `Task`. There's no need to manually call `StateHasChanged()`. Exceptions are logged when they occur.
+
+```cshtml
+<button class="btn btn-primary" onclick="@UpdateHeading">
+    Update heading
+</button>
+
+@functions {
+    async Task UpdateHeading(UIMouseEventArgs e)
+    {
+        ...
+    }
+}
+```
+
 For some events, event-specific event argument types are permitted. If access to one of these event types isn't necessary, it isn't required in the method call.
 
 The list of supported event arguments is:


### PR DESCRIPTION
Fixes #96 

We have perhaps a half-dozen to a dozen event handler examples in topics and samples. For example, one of our counters ...

```cshtml
<button class="btn btn-primary" onclick="@IncrementCount">Click me</button>

@functions {
    int currentCount = 0;

    [Parameter]
    private int IncrementAmount { get; set; } = 1;

    void IncrementCount()
    {
        currentCount += IncrementAmount;
    }
}
```

1. Should I go through and make all of our event handler examples async?
1. Should I move the async approach *above* the sync approach in this section (i.e., make it the empahsized approach)?
1. If 'yes,' should it also just say flat-out that async is recommended over sync for event handlers, which would remove all doubt as to which way to go?