### PR TITLE
Contributing DocFX Mono updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ DocFX requires the .NET Framework on Windows or Mono for Linux/macOS.
 
   ```
   alias docfx=mono $HOME/bin/docfx/docfx.exe
-  alias docfx-serve=mono $HOME/bin/docfx/docfx.exe serve _site
+  alias docfx-serve=mono $HOME/bin/docfx/docfx.exe --serve
   ```
 * Execute `docfx` from the root of the repo to build the site. Execute `docfx-serve` to view the site at `http://localhost:8080`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,8 @@ DocFX requires the .NET Framework on Windows or Mono for Linux/macOS.
 * Create a pair of aliases for **docfx** in a bash shell. The first alias is used to build the documentation. The second alias is used to build and serve the documentation.
 
   ```
-  alias docfx=mono $HOME/bin/docfx/docfx.exe
-  alias docfx-serve=mono $HOME/bin/docfx/docfx.exe --serve
+  alias docfx='mono $HOME/bin/docfx/docfx.exe'
+  alias docfx-serve='mono $HOME/bin/docfx/docfx.exe --serve'
   ```
 * Execute `docfx` from the root of the repo to build the site. Execute `docfx-serve` to view the site at `http://localhost:8080`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,6 @@ DocFX requires the .NET Framework on Windows or Mono for Linux/macOS.
   ```
   docfx --serve
   ```
-	
 * In a browser, navigate to `http://localhost:8080`.
 
 ### Mono instructions
@@ -103,22 +102,15 @@ DocFX requires the .NET Framework on Windows or Mono for Linux/macOS.
   ```
   brew install mono
   ```
-
 * Download the [latest version of DocFX](https://github.com/dotnet/docfx/releases).
-* Extract the archive to */bin/docfx*.
-* Create an alias for **docfx**:
+* Extract the archive to *$HOME/bin/docfx*.
+* Create an alias for **docfx** in a bash shell:
 
   ```
-  function docfx {
-    mono $HOME/bin/docfx/docfx.exe
-  }
-    
-  function docfx-serve {
-    mono $HOME/bin/docfx/docfx.exe serve _site
-  }
+  alias docfx=mono $HOME/bin/docfx/docfx.exe
+  alias docfx-serve=mono $HOME/bin/docfx/docfx.exe serve _site
   ```
-
-* Run `docfx` from the root of the repo to build the site, and `docfx-serve` to view the site at `http://localhost:8080`.
+* Run `docfx` from the root of the repo to build the site. Run `docfx-serve` to view the site at `http://localhost:8080`.
 
 ## Voice and tone
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,13 +104,13 @@ DocFX requires the .NET Framework on Windows or Mono for Linux/macOS.
   ```
 * Download the [latest version of DocFX](https://github.com/dotnet/docfx/releases).
 * Extract the archive to *$HOME/bin/docfx*.
-* Create an alias for **docfx** in a bash shell:
+* Create a pair of aliases for **docfx** in a bash shell. The first alias is used to build the documentation. The second alias is used to build and serve the documentation.
 
   ```
   alias docfx=mono $HOME/bin/docfx/docfx.exe
   alias docfx-serve=mono $HOME/bin/docfx/docfx.exe serve _site
   ```
-* Run `docfx` from the root of the repo to build the site. Run `docfx-serve` to view the site at `http://localhost:8080`.
+* Execute `docfx` from the root of the repo to build the site. Execute `docfx-serve` to view the site at `http://localhost:8080`.
 
 ## Voice and tone
 


### PR DESCRIPTION
Revises the Mono guidelines.

I have a Mac sitting here, but it isn't set up for GH, the repo, DocFX, or Mono. Do I need to test locally (which will take some time), or will the revised guidance ✨ **_Just Work_**:tm: ✨?

Also, this command doesn't quite look right to me (when run from the repo's root) ...

```console
mono $HOME/bin/docfx/docfx.exe serve _site
```

... shouldn't that just be ...

```console
mono $HOME/bin/docfx/docfx.exe --serve
```

... because I thought that `_site` folder is the default if the `--serve` switch is provided.

Thanks @mepda! :rocket: