### PR TITLE
Blazor templates have to be installed first

### DIFF
--- a/docs/tutorials/build-your-first-blazor-app.md
+++ b/docs/tutorials/build-your-first-blazor-app.md
@@ -35,6 +35,7 @@ To create the project in Visual Studio:
 > If not using Visual Studio, create the Blazor app at a command prompt on Windows, macOS, or Linux:
 >
 > ```console
+> dotnet new --install "Microsoft.AspNetCore.Blazor.Templates"
 > dotnet new blazor -o BlazorApp1
 > cd BlazorApp1
 > dotnet run


### PR DESCRIPTION
By default `dotnet new blazor` will fail due to the missing templates:

```
No templates matched the input template name: blazor.
```

...so those have to be installed first.
