### PR TITLE
Add the TabSet example to sample app

### DIFF
--- a/docs/common/samples/2.x/BlazorSample/Components/Tab.cshtml
+++ b/docs/common/samples/2.x/BlazorSample/Components/Tab.cshtml
@@ -1,0 +1,32 @@
+﻿@using BlazorSample.UIInterfaces
+@implements IDisposable
+@implements ITab
+
+<li>
+    <a onclick=@Activate class="nav-link @TitleCssClass" role="button">
+        @Title
+    </a>
+</li>
+
+@functions {
+    [CascadingParameter] TabSet ContainerTabSet { get; set; }
+    [Parameter] string Title { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; private set; }
+
+    string TitleCssClass => ContainerTabSet.ActiveTab == this ? "active" : null;
+
+    protected override void OnInit()
+    {
+        ContainerTabSet.AddTab(this);
+    }
+
+    public void Dispose()
+    {
+        ContainerTabSet.RemoveTab(this);
+    }
+
+    void Activate()
+    {
+        ContainerTabSet.SetActivateTab(this);
+    }
+}

--- a/docs/common/samples/2.x/BlazorSample/Components/TabSet.cshtml
+++ b/docs/common/samples/2.x/BlazorSample/Components/TabSet.cshtml
@@ -1,0 +1,44 @@
+﻿@using BlazorSample.UIInterfaces
+
+<!-- Display the tab headers -->
+<CascadingValue Value=this>
+    <ul class="nav nav-tabs">
+        @ChildContent
+    </ul>
+</CascadingValue>
+
+<!-- Display body for only the active tab -->
+<div class="nav-tabs-body p-4">
+    @ActiveTab?.ChildContent
+</div>
+
+@functions {
+    [Parameter] RenderFragment ChildContent { get; set; }
+
+    public ITab ActiveTab { get; private set; }
+
+    public void AddTab(ITab tab)
+    {
+        if (ActiveTab == null)
+        {
+            SetActivateTab(tab);
+        }
+    }
+
+    public void RemoveTab(ITab tab)
+    {
+        if (ActiveTab == tab)
+        {
+            SetActivateTab(null);
+        }
+    }
+
+    public void SetActivateTab(ITab tab)
+    {
+        if (ActiveTab != tab)
+        {
+            ActiveTab = tab;
+            StateHasChanged();
+        }
+    }
+}

--- a/docs/common/samples/2.x/BlazorSample/Pages/CascadingValuesParametersTabSet.cshtml
+++ b/docs/common/samples/2.x/BlazorSample/Pages/CascadingValuesParametersTabSet.cshtml
@@ -1,0 +1,163 @@
+@page "/CascadingValuesParametersTabSet"
+
+<h1>Cascading Values & Parameters - TabSet</h1>
+
+<!-- <snippet_TabSet> -->
+<TabSet>
+    <Tab Title="First tab">
+        <h4>Greetings from the first tab!</h4>
+
+        <label>
+            <input type="checkbox" bind=@showThirdTab />
+            Toggle third tab
+        </label>
+    </Tab>
+    <Tab Title="Second tab">
+        <h4>The second tab says Hello World!</h4>
+    </Tab>
+
+    @if (showThirdTab)
+    {
+        <Tab Title="Third tab">
+            <h4>Welcome to the disappearing third tab!</h4>
+            <p>Toggle this tab from the first tab.</p>
+        </Tab>
+    }
+</TabSet>
+<!-- </snippet_TabSet> -->
+
+<h2>ITab.cs</h2>
+
+<p>The <code>ITab</code> interface is implemented by tabs:</p>
+
+<pre><code>@@using Microsoft.AspNetCore.Blazor;
+
+namespace BlazorSample.UIInterfaces
+{
+    public interface ITab
+    {
+        RenderFragment ChildContent { get; }
+    }
+}</code></pre>
+
+<h2>Component</h2>
+
+<p>This component (<em>CascadingValuesParametersTabSet.cshtml</em>) uses the <code>TabSet</code> component, which contains several <code>Tab</code> components:</p>
+
+<pre><code>&lt;TabSet&gt;
+    &lt;Tab Title="First tab"&gt;
+        &lt;h4&gt;Greetings from the first tab!&lt;/h4&gt;
+
+        &lt;label&gt;
+            &lt;input type="checkbox" bind=@@showThirdTab /&gt;
+            Toggle third tab
+        &lt;/label&gt;
+    &lt;/Tab&gt;
+    &lt;Tab Title="Second tab"&gt;
+        &lt;h4&gt;The second tab says Hello World!&lt;/h4&gt;
+    &lt;/Tab&gt;
+
+    @@if (showThirdTab)
+    {
+        &lt;Tab Title="Third tab"&gt;
+            &lt;h4&gt;Welcome to the disappearing third tab!&lt;/h4&gt;
+            &lt;p&gt;Toggle this tab from the first tab.&lt;/p&gt;
+        &lt;/Tab&gt;
+    }
+&lt;/TabSet&gt;
+    
+@@functions
+{
+    bool showThirdTab;
+}</code></pre>
+
+<h2>TabSet.csthml</h2>
+
+<p>The child <code>Tab</code> components aren't explicitly passed as parameters to the <code>TabSet</code>. Instead, the child <code>Tab</code> components are part of the child content of the <code>TabSet</code>. However, the <code>TabSet</code> still needs to know about each <code>Tab</code> so that it can render the headers and the active tab. To enable this coordination without requiring additional code, the <code>TabSet</code> component <em>can provide itself as a cascading value</em> that is then picked up by the descendent <code>Tab</code> components.</p>
+
+<pre><code>@@using BlazorSample.UIInterfaces
+
+&lt;!-- Display the tab headers --&gt;
+&lt;CascadingValue Value=this&gt;
+    &lt;ul class="nav nav-tabs"&gt;
+        @@ChildContent
+    &lt;/ul&gt;
+&lt;/CascadingValue&gt;
+
+&lt;!-- Display body for only the active tab --&gt;
+&lt;div class="nav-tabs-body p-4"&gt;
+    @@ActiveTab?.ChildContent
+&lt;/div&gt;
+
+@@functions {
+    [Parameter] RenderFragment ChildContent { get; set; }
+
+    public ITab ActiveTab { get; private set; }
+
+    public void AddTab(ITab tab)
+    {
+        if (ActiveTab == null)
+        {
+            SetActivateTab(tab);
+        }
+    }
+
+    public void RemoveTab(ITab tab)
+    {
+        if (ActiveTab == tab)
+        {
+            SetActivateTab(null);
+        }
+    }
+
+    public void SetActivateTab(ITab tab)
+    {
+        if (ActiveTab != tab)
+        {
+            ActiveTab = tab;
+            StateHasChanged();
+        }
+    }
+}</code></pre>
+
+<h2>Tab.cshtml</h2>
+
+<p>The descendent <code>Tab</code> components capture the containing <code>TabSet</code> as a cascading parameter, so the <code>Tab</code> components add themselves to the <code>TabSet</code> and coordinate on which <code>Tab</code> is active.</p>
+
+<pre><code>@@using BlazorSample.UIInterfaces
+@@implements IDisposable
+@@implements ITab
+
+&lt;li&gt;
+    &lt;a onclick=@@Activate class="nav-link @@TitleCssClass" role="button"&gt;
+        @@Title
+    &lt;/a&gt;
+&lt;/li&gt;
+
+@@functions {
+    [CascadingParameter] TabSet ContainerTabSet { get; set; }
+    [Parameter] string Title { get; set; }
+    [Parameter] public RenderFragment ChildContent { get; private set; }
+
+    string TitleCssClass => ContainerTabSet.ActiveTab == this ? "active" : null;
+
+    protected override void OnInit()
+    {
+        ContainerTabSet.AddTab(this);
+    }
+
+    public void Dispose()
+    {
+        ContainerTabSet.RemoveTab(this);
+    }
+
+    void Activate()
+    {
+        ContainerTabSet.SetActivateTab(this);
+    }
+}</code></pre>
+
+@functions
+{
+bool showThirdTab;
+}

--- a/docs/common/samples/2.x/BlazorSample/Pages/CascadingValuesParametersTheme.cshtml
+++ b/docs/common/samples/2.x/BlazorSample/Pages/CascadingValuesParametersTheme.cshtml
@@ -1,14 +1,25 @@
-﻿@page "/cascadingvaluesparameters"
+﻿@page "/cascadingvaluesparameterstheme"
 @layout CascadingValuesParametersLayout
 @using BlazorSample.UIThemeClasses
 
-<h1>Cascading Values & Parameters</h1>
+<h1>Cascading Values & Parameters - Theme</h1>
 
 <p>Current count: @currentCount</p>
 
 <p><button class="btn" onclick="@IncrementCount">Increment Counter (Unthemed)</button></p>
 
 <p><button class="btn @ThemeInfo.ButtonClass" onclick="@IncrementCount">Increment Counter (Themed)</button></p>
+
+@functions {
+    int currentCount = 0;
+
+    [CascadingParameter] protected ThemeInfo ThemeInfo { get; set; }
+
+    void IncrementCount()
+    {
+        currentCount++;
+    }
+}
 
 <p>The layout component (<em>CascadingValuesParametersLayout.cshtml</em>) supplies a cascading <code>ThemeInfo</code> object to the components of the <code>Body</code> property that use this layout:</p>
 
@@ -34,7 +45,7 @@
     ThemeInfo theme = new ThemeInfo { ButtonClass = "btn-success" };
 }</code></pre>
 
-<p>This component (<em>CascadingValuesParameters.cshtml</em>) receives the <code>ThemeInfo</code> as a <code>CascadingParameter</code>. The parameter is used to style one of the buttons:</p>
+<p>This component (<em>CascadingValuesParametersTheme.cshtml</em>) receives the <code>ThemeInfo</code> as a <code>CascadingParameter</code>. The parameter is used to style one of the buttons:</p>
 
 <pre><code>&lt;button class="btn" onclick="@@IncrementCount"&gt;Increment Counter (Unthemed)&lt;/button&gt;
 
@@ -50,14 +61,3 @@
         currentCount++;
     }
 }</code></pre>
-
-@functions {
-    int currentCount = 0;
-
-    [CascadingParameter] protected ThemeInfo ThemeInfo { get; set; }
-
-    void IncrementCount()
-    {
-        currentCount++;
-    }
-}

--- a/docs/common/samples/2.x/BlazorSample/Shared/NavMenu.cshtml
+++ b/docs/common/samples/2.x/BlazorSample/Shared/NavMenu.cshtml
@@ -53,8 +53,13 @@
                     </NavLink>
                 </li>
                 <li>
-                    <NavLink href="CascadingValuesParameters">
-                        <span class="glyphicon glyphicon-th-list"></span> Cascading Values & Parameters
+                    <NavLink href="CascadingValuesParametersTheme">
+                        <span class="glyphicon glyphicon-th-list"></span> Cascading Values & Parameters &ndash; Theme
+                    </NavLink>
+                </li>
+                <li>
+                    <NavLink href="CascadingValuesParametersTabSet">
+                        <span class="glyphicon glyphicon-th-list"></span> Cascading Values & Parameters &ndash; TabSet
                     </NavLink>
                 </li>
                 <li>

--- a/docs/common/samples/2.x/BlazorSample/UIInterfaces/ITab.cs
+++ b/docs/common/samples/2.x/BlazorSample/UIInterfaces/ITab.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.AspNetCore.Blazor;
+
+namespace BlazorSample.UIInterfaces
+{
+    public interface ITab
+    {
+        RenderFragment ChildContent { get; }
+    }
+}

--- a/docs/common/samples/2.x/BlazorSample/wwwroot/css/site.css
+++ b/docs/common/samples/2.x/BlazorSample/wwwroot/css/site.css
@@ -23,6 +23,30 @@ p, .panel {
     margin-top: 15px
 }
 
+/* Styles for the TabSet/Tabs */
+.nav-tabs .nav-link {
+    border-color: #dee2e6 #dee2e6 #fff;
+    border-bottom-color: #dee2e6;
+    background-color: #f9f9f9;
+}
+
+.nav-tabs .active {
+    border-top: 4px solid #e0108b !important;
+    padding-top: 5px;
+    border-bottom: 1px solid transparent;
+    background-color: white;
+}
+
+.nav-tabs > li {
+    margin-bottom: -1px;
+}
+
+.nav-tabs-body {
+    border: 1px solid #dee2e6;
+    border-top-width: 0;
+    padding: 15px;
+}
+
 @media (max-width: 767px) {
     /* On small screens, the nav menu spans the full width of the screen. Leave a space for it. */
     body {

--- a/docs/common/samples/2.x/BlazorSample/wwwroot/index.html
+++ b/docs/common/samples/2.x/BlazorSample/wwwroot/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
-    <title>BlazorSample</title>
+    <title>Blazor Sample</title>
     <base href="/" />
     <link href="css/bootstrap/bootstrap.min.css" rel="stylesheet">
     <link href="css/site.css" rel="stylesheet">

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -5,7 +5,7 @@ description: Learn how to create and use Blazor components, the fundamental buil
 manager: wpickett
 ms.author: riande
 ms.custom: mvc
-ms.date: 08/03/2018
+ms.date: 12/25/2018
 ms.prod: asp.net-core
 ms.technology: aspnet
 ms.topic: article
@@ -568,7 +568,9 @@ Otherwise, the type parameter must be explicitly specified using an attribute th
 
 In some scenarios, it's inconvenient to flow data from an ancestor component to a descendent component using [component parameters](#component-parameters), especially when there are several component layers. Cascading values and parameters solve this problem by providing a convenient way for an ancestor component to provide a value to all of its descendent components. Cascading values and parameters also provide an approach for components to coordinate.
 
-In the following example from the sample app, the `ThemeInfo` class specifies the theme information to flow down the component hierarchy so that all of the buttons within a given part of the app share the same style.
+### Theme example
+
+In the following *Theme* example from the sample app, the `ThemeInfo` class specifies the theme information to flow down the component hierarchy so that all of the buttons within a given part of the app share the same style.
 
 *UIThemeClasses/ThemeInfo.cs*:
 
@@ -621,12 +623,12 @@ Binding with a string name value is relevant if you have multiple cascading valu
 
 Cascading values are bound to cascading parameters by type.
 
-In the sample app, the `CascadingValuesParameters` component binds to the `ThemeInfo` cascading value to a cascading parameter. The parameter is used to set the CSS class for one of the buttons displayed by the component.
+In the sample app, the `CascadingValuesParametersTheme` component binds to the `ThemeInfo` cascading value to a cascading parameter. The parameter is used to set the CSS class for one of the buttons displayed by the component.
 
-*Pages/CascadingValuesParameters.cshtml*:
+*Pages/CascadingValuesParametersTheme.cshtml*:
 
 ```cshtml
-@page "/cascadingvaluesparameters"
+@page "/cascadingvaluesparameterstheme"
 @layout CascadingValuesParametersLayout
 @using BlazorSample.UIThemeClasses
 
@@ -634,9 +636,17 @@ In the sample app, the `CascadingValuesParameters` component binds to the `Theme
 
 <p>Current count: @currentCount</p>
 
-<p><button class="btn" onclick="@IncrementCount">Increment Counter (Unthemed)</button></p>
+<p>
+    <button class="btn" onclick="@IncrementCount">
+        Increment Counter (Unthemed)
+    </button>
+</p>
 
-<p><button class="btn @ThemeInfo.ButtonClass" onclick="@IncrementCount">Increment Counter (Themed)</button></p>
+<p>
+    <button class="btn @ThemeInfo.ButtonClass" onclick="@IncrementCount">
+        Increment Counter (Themed)
+    </button>
+</p>
 
 @functions {
     int currentCount = 0;
@@ -650,56 +660,29 @@ In the sample app, the `CascadingValuesParameters` component binds to the `Theme
 }
 ```
 
-Cascading parameters also enable components to collaborate across the component hierarchy. For example, consider a `TabSet` component that contains several `Tab` components:
+### TabSet example
 
-```cshtml
-<TabSet>
-    <Tab Title="First tab">
-        <h4>First tab</h4>
-        This is the first tab.
-    </Tab>
+Cascading parameters also enable components to collaborate across the component hierarchy. For example, consider the following *TabSet* example in the sample app.
 
-    @if (showSecondTab)
-    {
-        <Tab Title="Second">
-            <h4>Second tab</h4>
-            You can toggle me.
-        </Tab>
-    }
+The sample app has an `ITab` interface that tabs implement:
 
-    <Tab Title="Third">
-        <h4>Third tab</h4>
+[!code-cs[](../common/samples/2.x/BlazorSample/UIInterfaces/ITab.cs)]
 
-        <label>
-            <input type="checkbox" bind=@showSecondTab />
-            Toggle second tab
-        </label>
-    </Tab>
-</TabSet>
-```
+The `CascadingValuesParametersTabSet` component uses the `TabSet` component, which contains several `Tab` components:
+
+[!code-cshtml[](../common/samples/2.x/BlazorSample/Pages/CascadingValuesParametersTabSet.cshtml?name=snippet_TabSet)]
 
 The child `Tab` components aren't explicitly passed as parameters to the `TabSet`. Instead, the child `Tab` components are part of the child content of the `TabSet`. However, the `TabSet` still needs to know about each `Tab` so that it can render the headers and the active tab. To enable this coordination without requiring additional code, the `TabSet` component *can provide itself as a cascading value* that is then picked up by the descendent `Tab` components.
 
-*TabSet.cshtml* (not included in the sample app):
+*Components/TabSet.cshtml*:
 
-```cshtml
-<!-- Display the tab headers -->
-<CascadingValue Value=this>
-    <ul class="nav nav-tabs">
-        @ChildContent
-    </ul>
-</CascadingValue>
-```
+[!code-cshtml[](../common/samples/2.x/BlazorSample/Components/TabSet.cshtml)]
 
 The descendent `Tab` components capture the containing `TabSet` as a cascading parameter, so the `Tab` components add themselves to the `TabSet` and coordinate on which `Tab` is active.
 
-*Tab.cshtml* (not included in the sample app):
+*Components/Tab.cshtml*:
 
-```cshtml
-[CascadingParameter] TabSet ContainerTabSet { get; set; }
-```
-
-The `TabSet` sample code is available in an [ITab.cs Gist on GitHub](https://gist.github.com/SteveSandersonMS/f10a552e1761ff759b1631d81a4428c3).
+[!code-cshtml[](../common/samples/2.x/BlazorSample/Components/Tab.cshtml)]
 
 ## Razor templates
 
@@ -714,7 +697,7 @@ The following example illustrates how to specify `RenderFragment` and `RenderFra
 *RazorTemplates.cshtml*:
 
 ```cshtml
-@{ 
+@{
     RenderFragment template = @<p>The time is @DateTime.Now.</p>;
     RenderFragment<Pet> petTemplate = (pet) => @<p>Your pet's name is @pet.Name.</p>;
 }


### PR DESCRIPTION
Fixes #348 

* Add the TabSet example to the sample app.
* Wire up the example code to the *Components* topic.

Shout out to @EdCharbeneau :rocket: for `role="button"` on the tab hyperlink element (over `href=""`) to prevent a nasty *browser clickjack* that redirects to the Index component.