### PR TITLE
Template name fix

### DIFF
--- a/docs/host-and-deploy/hosting-models.md
+++ b/docs/host-and-deploy/hosting-models.md
@@ -65,7 +65,7 @@ In the server-side hosting model, Blazor is executed on the server from within a
 
 ![Blazor server-side](https://user-images.githubusercontent.com/1874516/43042867-eaa8bb76-8d3b-11e8-8f1d-60768f86f710.png)
 
-To create a Blazor app using the server-side hosting model, use the **Blazor (Server-side on ASP.NET Core)** template (`blazorserver` when using [dotnet new](/dotnet/core/tools/dotnet-new) at a command prompt). An ASP.NET Core app hosts the Blazor server-side app and sets up the SignalR endpoint where clients connect. The ASP.NET Core app references the Blazor `Startup` class to both add the server-side Blazor services and to add the Blazor app to the request handling pipeline:
+To create a Blazor app using the server-side hosting model, use the **Blazor (Server-side in ASP.NET Core)** template (`blazorserver` when using [dotnet new](/dotnet/core/tools/dotnet-new) at a command prompt). An ASP.NET Core app hosts the Blazor server-side app and sets up the SignalR endpoint where clients connect. The ASP.NET Core app references the Blazor `Startup` class to both add the server-side Blazor services and to add the Blazor app to the request handling pipeline:
 
 ```csharp
 public class Startup


### PR DESCRIPTION
Incredibly minor but the template dialog in Visual Studio says 'in' rather than 'on' ASP.NET Core



<!--
When creating a new PR, please delete this template text and reference the issue number.

To automatically close the issue when the PR is merged, cite the issue number in the first line with ...

Fixes #Issue_Number

To only address an issue with a PR and not automatically close the issue when the PR merges, cite the issue number in the first line with ...

Addresses #Issue_Number
-->
