### PR TITLE
Use auto-generated TOC API namespace links

### DIFF
--- a/api/index.md
+++ b/api/index.md
@@ -11,28 +11,4 @@ Welcome to the Blazor API area!
 
 ## Namespaces
 
-[Microsoft.AspNetCore.Blazor](/api/Microsoft.AspNetCore.Blazor.html)  
-
-[Microsoft.AspNetCore.Blazor.Browser.Http](/api/Microsoft.AspNetCore.Blazor.Browser.Http.html)
-
-[Microsoft.AspNetCore.Blazor.Browser.Rendering](/api/Microsoft.AspNetCore.Blazor.Browser.Rendering.html)
-
-[Microsoft.AspNetCore.Blazor.Browser.Services](/api/Microsoft.AspNetCore.Blazor.Browser.Services.html)
-
-[Microsoft.AspNetCore.Blazor.Components](/api/Microsoft.AspNetCore.Blazor.Components.html)
-
-[Microsoft.AspNetCore.Blazor.Layouts](/api/Microsoft.AspNetCore.Blazor.Layouts.html)
-
-[Microsoft.AspNetCore.Blazor.Rendering](/api/Microsoft.AspNetCore.Blazor.Rendering.html)
-
-[Microsoft.AspNetCore.Blazor.RenderTree](/api/Microsoft.AspNetCore.Blazor.RenderTree.html)
-
-[Microsoft.AspNetCore.Blazor.Routing](/api/Microsoft.AspNetCore.Blazor.Routing.html)
-
-[Microsoft.AspNetCore.Blazor.Server](/api/Microsoft.AspNetCore.Blazor.Server.html)
-
-[Microsoft.AspNetCore.Blazor.Services](/api/Microsoft.AspNetCore.Blazor.Services.html)
-
-[Microsoft.AspNetCore.Builder](/api/Microsoft.AspNetCore.Builder.html)
-
-[Microsoft.JSInterop](/api/Microsoft.JSInterop.html)
+Use the namespace links in the Table of Contents.


### PR DESCRIPTION
We won't need to maintain the links (for the tiny bit of time left) using this approach, since the TOC links are auto-generated.

The sidebar TOC is named "Table of Contents" on small screen devices, so I use that phrase here.