### PR TITLE
Redirect to blazor docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://docs.microsoft.com/en-us/aspnet/core/client-side/spa/blazor/">
+    <meta http-equiv="refresh" content="0; url=https://docs.microsoft.com/aspnet/core/client-side/spa/blazor/">
 </head>
 <body>
 </body>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta http-equiv="refresh" content="0; url=https://docs.microsoft.com/aspnet/core/razor-components/">
+    <meta http-equiv="refresh" content="0; url=https://docs.microsoft.com/en-us/aspnet/core/client-side/spa/blazor/">
 </head>
 <body>
 </body>


### PR DESCRIPTION
@guardrex We should probably redirect the top level docs tab to point directly at the blazor docs.